### PR TITLE
Add video model and sample data

### DIFF
--- a/src/video.py
+++ b/src/video.py
@@ -1,0 +1,24 @@
+class Video:
+    """A class representing a single video."""
+
+    def __init__(self, title: str, video_id: str, tags):
+        self._title = title
+        self._video_id = video_id
+        # store tags as an immutable tuple
+        self._tags = tuple(tags) if tags else ()
+
+    @property
+    def title(self) -> str:
+        return self._title
+
+    @property
+    def video_id(self) -> str:
+        return self._video_id
+
+    @property
+    def tags(self):
+        return self._tags
+
+    def __str__(self) -> str:
+        tags_formatted = " ".join(self._tags)
+        return f"{self._title} ({self._video_id}) [{tags_formatted}]"

--- a/src/videos.txt
+++ b/src/videos.txt
@@ -1,0 +1,5 @@
+Amazing Cats|amazing_cats_video_id|#cat, #animal
+Another Cat Video|another_cat_video_id|#cat, #animal
+Funny Dogs|funny_dogs_video_id|#dog, #animal
+Life at Google|life_at_google_video_id|#google, #career
+Video about nothing|nothing_video_id|


### PR DESCRIPTION
## Summary
- introduce `Video` class to encapsulate video metadata and string formatting
- add sample `videos.txt` dataset and package init to allow `VideoLibrary` to load videos

## Testing
- `PYTHONPATH=. pytest test/videolibrary_test.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a25c4e575c8321a4cc3228bfda4079